### PR TITLE
feat: add status messages

### DIFF
--- a/kontan-server/src/blocks.ts
+++ b/kontan-server/src/blocks.ts
@@ -1,10 +1,11 @@
 /* eslint-disable max-len */
-import { ModalView, View, PlainTextOption } from '@slack/web-api';
+import { ModalView, View, PlainTextOption, Block } from '@slack/web-api';
 import {
   InboundDto,
   Status,
   UpcomingPresenceDto,
   Office,
+  StatusMessage,
 } from './services/OfficeService';
 import {
   getDay,
@@ -24,17 +25,23 @@ export const ACTIONS = {
   OFFICE_SELECT: 'office_select',
   CHECKIN_BUTTON: 'checkin_button',
   SETTINGS_BUTTON: 'settings_button',
+  STATUS_MESSAGE_BUTTON: 'status_message_button',
+  STATUS_MESSAGE_DAY: 'status_message_day',
+  STATUS_MESSAGE_MESSAGE: 'status_message_message',
 };
 
 export const BLOCK_IDS = {
   NFC_SERIAL: 'nfc_serial',
   HOME_OFFICE: 'home_office',
   COMPACT_MODE: 'compact_mode',
+  STATUS_MESSAGE_DAY: 'status_message_day',
+  STATUS_MESSAGE_MESSAGE: 'status_message_message',
 };
 
 export const MODALS = {
   REGISTER: 'register',
   SETTINGS: 'settings',
+  STATUS_MESSAGE: 'status_message',
 };
 
 export const newUserBlock: View = {
@@ -186,6 +193,109 @@ export const registerModal = (offices: Office[]): ModalView => {
   };
 };
 
+export const statusMessageModal = (
+  userId: User['slackUserId'],
+  plannedPresence: UpcomingPresenceDto[],
+): ModalView => {
+  return {
+    type: 'modal',
+    callback_id: MODALS.STATUS_MESSAGE,
+    title: {
+      type: 'plain_text',
+      text: 'Add a status message',
+      emoji: true,
+    },
+    submit: {
+      type: 'plain_text',
+      text: 'Add',
+      emoji: true,
+    },
+    close: {
+      type: 'plain_text',
+      text: 'Cancel',
+      emoji: true,
+    },
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'plain_text',
+          text: "Here you can add a status message to be displayed next to your name on specific days. Choose one of the days that you're already planned for",
+          emoji: true,
+        },
+      },
+      {
+        type: 'divider',
+      },
+      ...(!plannedPresence.length
+        ? [
+            {
+              type: 'section',
+              text: {
+                type: 'plain_text',
+                text: "It doesn't seem like you have any days planned in the near future :shrug: Please plan your days before adding status messages.",
+                emoji: true,
+              },
+            } as Block,
+          ]
+        : []),
+      ...(!!plannedPresence.length
+        ? [
+            {
+              type: 'input',
+              label: {
+                type: 'plain_text',
+                text: 'You are planned for these days, choose one',
+              },
+              block_id: BLOCK_IDS.STATUS_MESSAGE_DAY,
+              element: {
+                type: 'radio_buttons',
+                action_id: ACTIONS.STATUS_MESSAGE_DAY + '-action',
+                options: plannedPresence.reduce(
+                  (acc, curr) => [
+                    ...acc,
+                    {
+                      text: {
+                        type: 'plain_text',
+                        text: weekdayKeyToDayStr(curr.key),
+                      },
+                      value: curr.key,
+                    },
+                  ],
+                  [],
+                ),
+              },
+            } as Block,
+            {
+              type: 'input',
+              element: {
+                type: 'plain_text_input',
+                action_id: BLOCK_IDS.STATUS_MESSAGE_MESSAGE + '-action',
+              },
+              block_id: BLOCK_IDS.STATUS_MESSAGE_MESSAGE,
+              label: {
+                type: 'plain_text',
+                text: 'Your custom status for the day, emojis are supported',
+                emoji: true,
+              },
+            } as Block,
+            {
+              type: 'divider',
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'plain_text',
+                text: ':pro-tip: If you want to edit a status message, select the date of that status and add a new one.',
+                emoji: true,
+              },
+            } as Block,
+          ]
+        : []),
+    ],
+  };
+};
+
 export const settingsModal = (user: User): ModalView => {
   return {
     type: 'modal',
@@ -223,6 +333,11 @@ export const settingsModal = (user: User): ModalView => {
       },
       {
         type: 'input',
+        block_id: BLOCK_IDS.COMPACT_MODE,
+        label: {
+          type: 'plain_text',
+          text: 'Layout',
+        },
         element: {
           type: 'checkboxes',
           action_id: BLOCK_IDS.COMPACT_MODE + '-action',
@@ -247,26 +362,10 @@ export const settingsModal = (user: User): ModalView => {
             ],
           }),
         },
-        block_id: BLOCK_IDS.COMPACT_MODE,
-        label: {
-          type: 'plain_text',
-          text: 'Layout',
-        },
         optional: true,
       },
     ],
   };
-};
-
-const getUserStatus = (status: Status): string => {
-  switch (status) {
-    case 'INBOUND':
-      return ':white_check_mark:';
-    case 'OUTBOUND':
-      return '_Checked out_ :house_with_garden:';
-    default:
-      return '_Not checked in yet_';
-  }
 };
 
 export const homeScreen = ({
@@ -274,11 +373,13 @@ export const homeScreen = ({
   plannedPresence,
   user,
   offices,
+  statusMessages,
 }: {
   presentUsers: InboundDto[];
   plannedPresence: UpcomingPresenceDto[];
   user: User;
   offices: Office[];
+  statusMessages: StatusMessage[];
 }): View => {
   const initialOptions = new Array<PlainTextOption>();
   const inputOptions = new Array<PlainTextOption>();
@@ -293,6 +394,28 @@ export const homeScreen = ({
       value: `${office.id}`,
     } as PlainTextOption;
   });
+
+  const getStatusMessage = (userId: string, weekday: string) => {
+    const message = statusMessages.find(
+      (s) => s.slackUserId === userId && s.dayKey === weekday,
+    )?.text;
+    return message ? ` - ${message}` : '';
+  };
+
+  const getUserStatus = (
+    status: Status,
+    userId: string,
+    weekday: string,
+  ): string => {
+    switch (status) {
+      case 'INBOUND':
+        return ':white_check_mark:' + getStatusMessage(userId, weekday);
+      case 'OUTBOUND':
+        return '_Checked out_ :house_with_garden:';
+      default:
+        return '_Not checked in yet_' + getStatusMessage(userId, weekday);
+    }
+  };
 
   const initialOfficeOption = officeNames.find(
     (office) => office.value === user.office,
@@ -365,7 +488,12 @@ export const homeScreen = ({
                     type: 'mrkdwn',
                     text: presentUsers
                       .map(
-                        (usr) => `${usr.name} - ${getUserStatus(usr.status)}`,
+                        (usr) =>
+                          `${usr.name} - ${getUserStatus(
+                            usr.status,
+                            usr.slackUserId,
+                            today,
+                          )}`,
                       )
                       .join(', '),
                   },
@@ -377,8 +505,13 @@ export const homeScreen = ({
           return {
             type: 'section',
             text: {
-              type: 'mrkdwn',
-              text: `${usr.name} - ${getUserStatus(usr.status)}`,
+              type: 'plain_text',
+              emoji: true,
+              text: `${usr.name} - ${getUserStatus(
+                usr.status,
+                usr.slackUserId,
+                today,
+              )}`,
             },
           };
         })),
@@ -465,6 +598,21 @@ export const homeScreen = ({
         },
       },
       {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: {
+              type: 'plain_text',
+              text: ':speech_balloon: Add a status message',
+              emoji: true,
+            },
+            value: ACTIONS.STATUS_MESSAGE_BUTTON,
+            action_id: ACTIONS.STATUS_MESSAGE_BUTTON,
+          },
+        ],
+      },
+      {
         type: 'section',
         text: {
           type: 'plain_text',
@@ -491,7 +639,7 @@ export const homeScreen = ({
       ...todayBlocks,
       ...plannedPresence
         .filter((item) => item.key !== today)
-        .map(({ weekday, users }) => {
+        .map(({ weekday, users, key }) => {
           const noOne = {
             type: 'section',
             text: {
@@ -514,9 +662,16 @@ export const homeScreen = ({
                         {
                           type: 'section',
                           text: {
-                            type: 'mrkdwn',
+                            type: 'plain_text',
+                            emoji: true,
                             text: users
-                              .map((usr) => `_${usr.name}_`)
+                              .map(
+                                (usr) =>
+                                  `${usr.name}${getStatusMessage(
+                                    usr.slackUserId,
+                                    key,
+                                  )}`,
+                              )
                               .join(', '),
                           },
                         },
@@ -527,8 +682,12 @@ export const homeScreen = ({
                   return {
                     type: 'section',
                     text: {
-                      type: 'mrkdwn',
-                      text: `_${usr.name}_`,
+                      type: 'plain_text',
+                      emoji: true,
+                      text: `${usr.name}${getStatusMessage(
+                        usr.slackUserId,
+                        key,
+                      )}`,
                     },
                   };
                 })),


### PR DESCRIPTION
A status message will be displayed next to the users name under TODAY, and also in the list of upcoming days. 

When it's displayed under TODAY, it will only be displayed if the user hasn't checked in or has checked in. I.e. when user has checked out, the status message won't be displayed anymore. 

When a user un-ticks their presence for a day, if there's a status message for that day, it will be removed.

Status messages are also removed from DB when the date has passed.